### PR TITLE
Addition of Asynchoronous Object Temp processing from intermediate raw values

### DIFF
--- a/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
+++ b/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
@@ -69,8 +69,8 @@ void loop()
 	
 	while (myStatus != MLX90632::status::SENSOR_SUCCESS)
 	{
-		myTempSensor.getRawObjectTemp(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
-		objectTemp = myTempSensor.getProcessedObjectTemp(AMB, Sto);
+		myTempSensor.getRawSensorValues(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
+		objectTemp = myTempSensor.getObjectTemp(AMB, Sto);
 	}
 	Serial.print("AMB:");
 	Serial.println(AMB);

--- a/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
+++ b/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
@@ -26,7 +26,7 @@ void setup()
 	myWire.begin();
 	pinPeripheral(11, PIO_SERCOM);
 	pinPeripheral(13, PIO_SERCOM);
-	myWire.setClock(1000000);
+	myWire.setClock(400000);
 
 	//  myTempSensor.enableDebugging(Serial);
 	MLX90632::status myStatus;
@@ -47,35 +47,23 @@ void setup()
 	Serial.print("Value stored in EE_MEAS2: 0x");
 	Serial.println(valueInMemory, HEX);
 
-	// setup digital outputs to visualize loop timing
-	//pinMode(14, OUTPUT);
-	//digitalWrite(14, LOW);
-	//pinMode(16, OUTPUT);
-	//digitalWrite(16, LOW);
-	//pinMode(10, OUTPUT);
-	//digitalWrite(10, LOW);
 }
 
 void loop()
 {
 	float objectTemp;
-	float AMB;
-	float Sto;
-	MLX90632::status myStatus;
-	objectTemp = myTempSensor.startRawSensorValues(myStatus); //start measurement conversion
-	myStatus = MLX90632::status::SENSOR_NO_NEW_DATA;
-	
-	while (myStatus != MLX90632::status::SENSOR_SUCCESS)
-	{
-		myTempSensor.getRawSensorValues(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
-		objectTemp = myTempSensor.getObjectTemp(AMB, Sto);
-	}
-	Serial.print("AMB:");
-	Serial.println(AMB);
-	Serial.print("Sto:");
-	Serial.println(Sto);
+
+	//For the world
+	objectTemp = myTempSensor.getObjectTemp(); //Get the temperature of the object we're looking at in C
 	Serial.print("Object temperature: ");
 	Serial.print(objectTemp, 2);
-	Serial.println(" C");
+	Serial.print(" C");
 
+	//For us silly people that use Fahrenheit
+	/*objectTemp = myTempSensor.getObjectTempF(); //Get the temperature of the object we're looking at in F
+	Serial.print("Object temperature: ");
+	Serial.print(objectTemp, 2);
+	Serial.print(" F");*/
+
+	Serial.println();
 }

--- a/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
+++ b/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
@@ -61,10 +61,8 @@ void loop()
 	float objectTemp;
 	float AMB;
 	float Sto;
-	objectTemp = myTempSensor.startConversionObjectTemp(); //start measurement conversion
-	// ToDo: change this to automatically be updated with the set measurement rate
-	//delay(150);  // Delay is dependent on the refresh rate set for the sensor on board, see datasheet
 	MLX90632::status myStatus;
+	objectTemp = myTempSensor.startRawSensorValues(myStatus); //start measurement conversion
 	myStatus = MLX90632::status::SENSOR_NO_NEW_DATA;
 	
 	while (myStatus != MLX90632::status::SENSOR_SUCCESS)

--- a/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
+++ b/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
@@ -31,7 +31,7 @@ void setup()
 	//  myTempSensor.enableDebugging(Serial);
 	MLX90632::status myStatus;
 	myTempSensor.begin(address, myWire, myStatus);
-
+	//myTempSensor.enableDebugging();
 	if (myStatus != MLX90632::status::SENSOR_SUCCESS)
 	{
 		Serial.println("MLX90632 communication failed");
@@ -63,17 +63,21 @@ void loop()
 	float Sto;
 	objectTemp = myTempSensor.startConversionObjectTemp(); //start measurement conversion
 	// ToDo: change this to automatically be updated with the set measurement rate
-	delay(150);  // Delay is dependent on the refresh rate set for the sensor on board, see datasheet
+	//delay(150);  // Delay is dependent on the refresh rate set for the sensor on board, see datasheet
 	MLX90632::status myStatus;
 	myStatus = MLX90632::status::SENSOR_NO_NEW_DATA;
 	
 	while (myStatus != MLX90632::status::SENSOR_SUCCESS)
 	{
-		myTempSensor.updateRawObjectTemp(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
+		myTempSensor.getRawObjectTemp(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
 		objectTemp = myTempSensor.getProcessedObjectTemp(AMB, Sto);
 	}
-
+	Serial.print("AMB:");
+	Serial.println(AMB);
+	Serial.print("Sto:");
+	Serial.println(Sto);
 	Serial.print("Object temperature: ");
 	Serial.print(objectTemp, 2);
 	Serial.println(" C");
+
 }

--- a/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
+++ b/examples/EmotiBit_Example1-Basic_Reading/EmotiBit_Example1-Basic_Reading.ino
@@ -59,16 +59,18 @@ void setup()
 void loop()
 {
 	float objectTemp;
-
-	objectTemp = myTempSensor.start_getObjectTemp(); //start measurement conversion
-
+	float AMB;
+	float Sto;
+	objectTemp = myTempSensor.startConversionObjectTemp(); //start measurement conversion
+	// ToDo: change this to automatically be updated with the set measurement rate
 	delay(150);  // Delay is dependent on the refresh rate set for the sensor on board, see datasheet
 	MLX90632::status myStatus;
 	myStatus = MLX90632::status::SENSOR_NO_NEW_DATA;
 	
 	while (myStatus != MLX90632::status::SENSOR_SUCCESS)
 	{
-		objectTemp = myTempSensor.end_getObjectTemp(myStatus); //Get the temperature of the object we're looking at in C
+		myTempSensor.updateRawObjectTemp(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
+		objectTemp = myTempSensor.getProcessedObjectTemp(AMB, Sto);
 	}
 
 	Serial.print("Object temperature: ");

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MLX90632
-version=1.0.6
+version=1.0.7
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs <nitin@connectedfuturelabs.com>
 sentence=Library for using MLX90632 FIR sensor

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MLX90632
-version=1.0.7
+version=1.0.8
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs <nitin@connectedfuturelabs.com>
 sentence=Library for using MLX90632 FIR sensor

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MLX90632
-version=1.0.3
+version=1.0.4
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs <nitin@connectedfuturelabs.com>
 sentence=Library for using MLX90632 FIR sensor

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MLX90632
-version=1.0.4
+version=1.0.5
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs <nitin@connectedfuturelabs.com>
 sentence=Library for using MLX90632 FIR sensor

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit MLX90632
-version=1.0.5
+version=1.0.6
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=Connected Future Labs <nitin@connectedfuturelabs.com>
 sentence=Library for using MLX90632 FIR sensor

--- a/src/SparkFun_MLX90632_Arduino_Library.cpp
+++ b/src/SparkFun_MLX90632_Arduino_Library.cpp
@@ -354,7 +354,6 @@ float MLX90632::getObjectTemp(float AMB, float Sto)
     objectTemp = objectTemp - 273.15 - Hb;
 
     TO0 = objectTemp;
-	_lastObjectTemp = TO0;
 
     if (_printDebug)
     {
@@ -373,6 +372,14 @@ float MLX90632::getObjectTemp(float AMB, float Sto)
       _debugPort->println(objectTemp, 7);
     }
 
+  }
+  if (!isnan(TO0))
+  {
+	  _lastObjectTemp = TO0;
+  }
+  else
+  {
+	  TO0 = _lastObjectTemp;
   }
   return (TO0);
 }

--- a/src/SparkFun_MLX90632_Arduino_Library.cpp
+++ b/src/SparkFun_MLX90632_Arduino_Library.cpp
@@ -209,10 +209,6 @@ bool MLX90632::startRawSensorValues(status& returnError)
 	return (returnError == SENSOR_SUCCESS);
 }
 
-//float MLX90632::getRawObjectTemp() {
-//	MLX90632::status returnError;
-//	return (getRawObjectTemp(returnError));
-//}
 
 void MLX90632::getRawSensorValues(status& returnError, float &AMB, float &Sto) {
 	// Removed following because it doens't seem to do anything
@@ -381,6 +377,35 @@ float MLX90632::getObjectTemp(float AMB, float Sto)
   return (TO0);
 }
 
+
+float MLX90632::getObjectTemp()
+{
+	status returnError;
+	return getObjectTemp(returnError);
+}
+
+float MLX90632::getObjectTemp(MLX90632::status &returnError)
+{
+	float AMB, Sto;
+	float objectTemp;
+
+	bool statusStart = false;
+	while (!statusStart)
+	{
+		statusStart = startRawSensorValues(returnError); //start measurement conversion
+	}
+
+	returnError = MLX90632::status::SENSOR_NO_NEW_DATA;
+
+	while (returnError != MLX90632::status::SENSOR_SUCCESS)
+	{
+		getRawSensorValues(returnError, AMB, Sto);
+	}
+	objectTemp = getObjectTemp(AMB, Sto);
+	return objectTemp;
+}
+
+
 //Convert temp to F
 float MLX90632::getObjectTempF()
 {
@@ -391,24 +416,7 @@ float MLX90632::getObjectTempF()
 		float AMB;
 		float Sto;
 
-		// Add a delay corresponding to refresh rate per the datasheet
-		//delay(1000.f / (float) (_refreshRate == 0 ? 0.5f : _refreshRate));
-
-		MLX90632::status myStatus;
-		myStatus = MLX90632::status::SENSOR_NO_NEW_DATA;
-		while (true)
-		{
-			getRawSensorValues(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
-			tempC = getObjectTemp(AMB, Sto);
-			if (myStatus == MLX90632::status::SENSOR_SUCCESS)
-			{
-				break;
-			}
-			else
-			{
-				delay(1);
-			}
-		}
+		tempC = getObjectTemp();
 
 		float tempF = tempC * 9.0/5.0 + 32.0;
 		return(tempF);

--- a/src/SparkFun_MLX90632_Arduino_Library.cpp
+++ b/src/SparkFun_MLX90632_Arduino_Library.cpp
@@ -193,12 +193,8 @@ boolean MLX90632::begin(uint8_t deviceAddress, TwoWire &wirePort, status &return
 //Read all calibration values and calculate the temperature of the thing we are looking at
 //Depending on mode, initiates a measurement
 //If in sleep or step mode, clears the new_data bit, sets the SOC bit
-bool MLX90632::startConversionObjectTemp()
-{
-  MLX90632::status returnError;
-  return (startConversionObjectTemp(returnError));
-}
-bool MLX90632::startConversionObjectTemp(status& returnError)
+
+bool MLX90632::startRawSensorValues(status& returnError)
 {
 	returnError = SENSOR_SUCCESS;
 
@@ -388,7 +384,8 @@ float MLX90632::getObjectTemp(float AMB, float Sto)
 //Convert temp to F
 float MLX90632::getObjectTempF()
 {
-	if (startConversionObjectTemp())
+	status myStatus;
+	if (startRawSensorValues(myStatus))
 	{
 		float tempC;
 		float AMB;

--- a/src/SparkFun_MLX90632_Arduino_Library.cpp
+++ b/src/SparkFun_MLX90632_Arduino_Library.cpp
@@ -347,7 +347,7 @@ float MLX90632::getObjectTemp(float AMB, float Sto)
 
     ambientTempK = TAdut + 273.15;
 
-    bigFraction = Sto / (1 * Fa * Ha * (1 + Ga * (TOdut - TO0) + Fb * (TAdut - TA0)));
+    bigFraction = Sto / (1 * Fa * Ha * (1 + Ga * (TOdut - _lastObjectTemp) + Fb * (TAdut - TA0)));
 
     objectTemp = bigFraction + pow(ambientTempK, 4);
     objectTemp = pow(objectTemp, 0.25); //Take 4th root
@@ -376,10 +376,6 @@ float MLX90632::getObjectTemp(float AMB, float Sto)
   if (!isnan(TO0))
   {
 	  _lastObjectTemp = TO0;
-  }
-  else
-  {
-	  TO0 = _lastObjectTemp;
   }
   return (TO0);
 }

--- a/src/SparkFun_MLX90632_Arduino_Library.cpp
+++ b/src/SparkFun_MLX90632_Arduino_Library.cpp
@@ -218,7 +218,7 @@ bool MLX90632::startConversionObjectTemp(status& returnError)
 //	return (getRawObjectTemp(returnError));
 //}
 
-void MLX90632::getRawObjectTemp(status& returnError, float &AMB, float &Sto) {
+void MLX90632::getRawSensorValues(status& returnError, float &AMB, float &Sto) {
 	// Removed following because it doens't seem to do anything
   //gatherSensorTemp(returnError);
 
@@ -324,7 +324,7 @@ void MLX90632::getRawObjectTemp(status& returnError, float &AMB, float &Sto) {
 }
 
 
-float MLX90632::getProcessedObjectTemp(float AMB, float Sto)
+float MLX90632::getObjectTemp(float AMB, float Sto)
 {	
 	if (AMB == -1.0 && Sto == -1.0)
 	{
@@ -401,8 +401,8 @@ float MLX90632::getObjectTempF()
 		myStatus = MLX90632::status::SENSOR_NO_NEW_DATA;
 		while (true)
 		{
-			getRawObjectTemp(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
-			tempC = getProcessedObjectTemp(AMB, Sto);
+			getRawSensorValues(myStatus, AMB, Sto); //Get the temperature of the object we're looking at in C
+			tempC = getObjectTemp(AMB, Sto);
 			if (myStatus == MLX90632::status::SENSOR_SUCCESS)
 			{
 				break;

--- a/src/SparkFun_MLX90632_Arduino_Library.h
+++ b/src/SparkFun_MLX90632_Arduino_Library.h
@@ -143,6 +143,8 @@ class MLX90632 {
     bool startRawSensorValues(status &returnError);
 	//float getRawObjectTemp();
 	void getRawSensorValues(status &returnError, float &AMB, float &Sto);
+	float getObjectTemp();
+	float getObjectTemp(MLX90632::status &returnError);
 	float getObjectTemp(float AMb, float Sto);
 	float getObjectTempF();
     float getSensorTemp();

--- a/src/SparkFun_MLX90632_Arduino_Library.h
+++ b/src/SparkFun_MLX90632_Arduino_Library.h
@@ -143,7 +143,7 @@ class MLX90632 {
     bool startConversionObjectTemp();
     bool startConversionObjectTemp(status &returnError);
 	//float getRawObjectTemp();
-	void updateRawObjectTemp(status &returnError, float &AMB, float &Sto);
+	void getRawObjectTemp(status &returnError, float &AMB, float &Sto);
 	float getProcessedObjectTemp(float AMb, float Sto);
 	float getObjectTempF();
     float getSensorTemp();
@@ -177,5 +177,6 @@ class MLX90632 {
 
     Stream *_debugPort; //The stream to send debug messages to if enabled
     boolean _printDebug = false; //Flag to print debugging variables
+	float _lastObjectTemp;
 
 };

--- a/src/SparkFun_MLX90632_Arduino_Library.h
+++ b/src/SparkFun_MLX90632_Arduino_Library.h
@@ -140,8 +140,7 @@ class MLX90632 {
     void enableDebugging(Stream &debugPort = Serial); //Turn on debug printing. If user doesn't specify then Serial will be used.
     void disableDebugging(); //Turn off debug printing
 
-    bool startConversionObjectTemp();
-    bool startConversionObjectTemp(status &returnError);
+    bool startRawSensorValues(status &returnError);
 	//float getRawObjectTemp();
 	void getRawSensorValues(status &returnError, float &AMB, float &Sto);
 	float getObjectTemp(float AMb, float Sto);

--- a/src/SparkFun_MLX90632_Arduino_Library.h
+++ b/src/SparkFun_MLX90632_Arduino_Library.h
@@ -143,8 +143,8 @@ class MLX90632 {
     bool startConversionObjectTemp();
     bool startConversionObjectTemp(status &returnError);
 	//float getRawObjectTemp();
-	void getRawObjectTemp(status &returnError, float &AMB, float &Sto);
-	float getProcessedObjectTemp(float AMb, float Sto);
+	void getRawSensorValues(status &returnError, float &AMB, float &Sto);
+	float getObjectTemp(float AMb, float Sto);
 	float getObjectTempF();
     float getSensorTemp();
     float getSensorTemp(status &returnError);

--- a/src/SparkFun_MLX90632_Arduino_Library.h
+++ b/src/SparkFun_MLX90632_Arduino_Library.h
@@ -140,10 +140,11 @@ class MLX90632 {
     void enableDebugging(Stream &debugPort = Serial); //Turn on debug printing. If user doesn't specify then Serial will be used.
     void disableDebugging(); //Turn off debug printing
 
-    bool start_getObjectTemp();
-    bool start_getObjectTemp(status &returnError);
-	float end_getObjectTemp();
-	float end_getObjectTemp(status &returnError);
+    bool startConversionObjectTemp();
+    bool startConversionObjectTemp(status &returnError);
+	//float getRawObjectTemp();
+	void updateRawObjectTemp(status &returnError, float &AMB, float &Sto);
+	float getProcessedObjectTemp(float AMb, float Sto);
 	float getObjectTempF();
     float getSensorTemp();
     float getSensorTemp(status &returnError);
@@ -167,7 +168,7 @@ class MLX90632 {
 
   private:
 
-		uint8_t _refreshRate = 2;
+	uint8_t _refreshRate = 2;
     float gatherSensorTemp(status &returnError);
 
     //Variables


### PR DESCRIPTION
## Description
Adding Asynchronous object Temp calculation. Intermediate values are now calculated and stored based on sensor output. These intermediate values can now be used to calculate final object temperature.

### New Features
- 2 step calculation for determining object temperature
  - `Step1`: Convert raw Sensor output to intermediate **AMB** and **Sto** variables.
  - `Step2`: Convert **AMB** and **Sto** into final object temperature.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking changes (upgrade EmotiBit FW to v1.0.57)

### How Has This Been Tested?
- Tested by uploading the FW(v1.0.57) on EmotiBit V02H HW along with EmotiBit Oscilloscope [v1.0.17](https://github.com/EmotiBit/ofxEmotiBit/releases/tag/v1.0.17)

**Test Configuration**:
* Firmware version: EmotiBit FW v1.0.57

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

### Compatibility
- Works only on EmotiBit V02H
